### PR TITLE
[CZ-260] 전역으로 투표 생성완료 모달 관리

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -3942,7 +3942,8 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["react-dom", "virtual:105a91f90b82bcacf40b5632b18e55bd637d4fb5be4d370b87556c6b60c68cac91184637fa7b2a281947c4b62808b626114fdaabcabcc4f130e4c47c8463f2e4#npm:18.2.0"],\
             ["react-is", "npm:18.2.0"],\
             ["styled-components", "virtual:105a91f90b82bcacf40b5632b18e55bd637d4fb5be4d370b87556c6b60c68cac91184637fa7b2a281947c4b62808b626114fdaabcabcc4f130e4c47c8463f2e4#npm:5.3.6"],\
-            ["typescript", "patch:typescript@npm%3A4.9.4#~builtin<compat/typescript>::version=4.9.4&hash=d73830"]\
+            ["typescript", "patch:typescript@npm%3A4.9.4#~builtin<compat/typescript>::version=4.9.4&hash=d73830"],\
+            ["zustand", "virtual:3b35f13cd85e54150adb716a320c9e7fac21d3e832e9f84e1ba4e5caff624f9a39f891453e832192085fc3c3d0959304dbe515f0512a057755bb8be5d918eb64#npm:4.3.2"]\
           ],\
           "linkType": "SOFT"\
         }]\
@@ -8593,6 +8594,33 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./.yarn/cache/yocto-queue-npm-0.1.0-c6c9a7db29-f77b3d8d00.zip/node_modules/yocto-queue/",\
           "packageDependencies": [\
             ["yocto-queue", "npm:0.1.0"]\
+          ],\
+          "linkType": "HARD"\
+        }]\
+      ]],\
+      ["zustand", [\
+        ["npm:4.3.2", {\
+          "packageLocation": "./.yarn/cache/zustand-npm-4.3.2-99ceed0a38-fc443abf5b.zip/node_modules/zustand/",\
+          "packageDependencies": [\
+            ["zustand", "npm:4.3.2"]\
+          ],\
+          "linkType": "SOFT"\
+        }],\
+        ["virtual:3b35f13cd85e54150adb716a320c9e7fac21d3e832e9f84e1ba4e5caff624f9a39f891453e832192085fc3c3d0959304dbe515f0512a057755bb8be5d918eb64#npm:4.3.2", {\
+          "packageLocation": "./.yarn/__virtual__/zustand-virtual-514b785024/0/cache/zustand-npm-4.3.2-99ceed0a38-fc443abf5b.zip/node_modules/zustand/",\
+          "packageDependencies": [\
+            ["zustand", "virtual:3b35f13cd85e54150adb716a320c9e7fac21d3e832e9f84e1ba4e5caff624f9a39f891453e832192085fc3c3d0959304dbe515f0512a057755bb8be5d918eb64#npm:4.3.2"],\
+            ["@types/immer", null],\
+            ["@types/react", "npm:18.0.26"],\
+            ["immer", null],\
+            ["react", "npm:18.2.0"],\
+            ["use-sync-external-store", "virtual:2cdcbad206c3b01af286fb19b0b28daf61a00d8675ec777558af85d4eb46021430d5e303cd978b3e26321d79e6db5af5a4fdaf0f1b253b1597ebc6fe1aebac63#npm:1.2.0"]\
+          ],\
+          "packagePeers": [\
+            "@types/immer",\
+            "@types/react",\
+            "immer",\
+            "react"\
           ],\
           "linkType": "HARD"\
         }]\

--- a/apps/web/components/common/NumberOfSolver.tsx
+++ b/apps/web/components/common/NumberOfSolver.tsx
@@ -6,7 +6,7 @@ interface Props {
   children: React.ReactNode;
 }
 
-function SolversMessage({ children }: Props) {
+function NumberOfSolver({ children }: Props) {
   return <Message>{children}</Message>;
 }
 
@@ -26,4 +26,4 @@ const Message = styled.div`
   }
 `;
 
-export default SolversMessage;
+export default NumberOfSolver;

--- a/apps/web/components/common/SolversMessage.tsx
+++ b/apps/web/components/common/SolversMessage.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import styled from "styled-components";
+import { media } from "styles/media";
+
+interface Props {
+  children: React.ReactNode;
+}
+
+function SolversMessage({ children }: Props) {
+  return <Message>{children}</Message>;
+}
+
+const Message = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 106px;
+  height: 24px;
+  border-radius: 4px;
+  margin-left: 4px;
+  background-color: ${({ theme }) => theme.palette.background.black};
+  color: ${({ theme }) => theme.palette.ink.lightest};
+  ${media.medium} {
+    width: 110px;
+    height: 28px;
+  }
+`;
+
+export default SolversMessage;

--- a/apps/web/components/common/TargetMessage.tsx
+++ b/apps/web/components/common/TargetMessage.tsx
@@ -1,0 +1,28 @@
+import { media } from "@chooz/ui/styles/media";
+import React from "react";
+import styled from "styled-components";
+
+interface Props {
+  children: React.ReactNode;
+}
+
+function TargetMessage({ children }: Props) {
+  return <Message>{children}</Message>;
+}
+
+const Message = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 149px;
+  height: 24px;
+  border-radius: 4px;
+  background-color: ${({ theme }) => theme.palette.main.point};
+  color: ${({ theme }) => theme.palette.ink.lightest};
+  ${media.medium} {
+    width: 154px;
+    height: 28px;
+  }
+`;
+
+export default TargetMessage;

--- a/apps/web/components/voteList/VoteItem.tsx
+++ b/apps/web/components/voteList/VoteItem.tsx
@@ -1,5 +1,5 @@
 import { media } from "@chooz/ui/styles/media";
-import SolversMessage from "components/common/SolversMessage";
+import NumberOfSolver from "components/common/NumberOfSolver";
 import TargetMessage from "components/common/TargetMessage";
 import Image from "next/image";
 import { BookmarkIcon } from "public/icons";
@@ -16,7 +16,7 @@ function VoteItem() {
       <VoteInfo>
         <MessageContainer>
           <TargetMessage>이 고민을 찾고있는 분이에요!</TargetMessage>
-          <SolversMessage>🔥3,645명 해결중!</SolversMessage>
+          <NumberOfSolver>🔥3,645명 해결중!</NumberOfSolver>
         </MessageContainer>
         <BookmarkIconStyled />
       </VoteInfo>

--- a/apps/web/components/voteList/VoteItem.tsx
+++ b/apps/web/components/voteList/VoteItem.tsx
@@ -1,4 +1,6 @@
 import { media } from "@chooz/ui/styles/media";
+import SolversMessage from "components/common/SolversMessage";
+import TargetMessage from "components/common/TargetMessage";
 import Image from "next/image";
 import { BookmarkIcon } from "public/icons";
 import { Eximg1, Eximg2 } from "public/images";
@@ -14,7 +16,7 @@ function VoteItem() {
       <VoteInfo>
         <MessageContainer>
           <TargetMessage>이 고민을 찾고있는 분이에요!</TargetMessage>
-          <NumberOfVote>🔥3,645명 해결중!</NumberOfVote>
+          <SolversMessage>🔥3,645명 해결중!</SolversMessage>
         </MessageContainer>
         <BookmarkIconStyled />
       </VoteInfo>
@@ -79,37 +81,6 @@ const VoteInfo = styled.div`
 
 const MessageContainer = styled.div`
   display: flex;
-`;
-
-const TargetMessage = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 149px;
-  height: 24px;
-  border-radius: 4px;
-  background-color: ${({ theme }) => theme.palette.main.point};
-  color: ${({ theme }) => theme.palette.ink.lightest};
-  ${media.medium} {
-    width: 154px;
-    height: 28px;
-  }
-`;
-
-const NumberOfVote = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 106px;
-  height: 24px;
-  border-radius: 4px;
-  margin-left: 4px;
-  background-color: ${({ theme }) => theme.palette.background.black};
-  color: ${({ theme }) => theme.palette.ink.lightest};
-  ${media.medium} {
-    width: 110px;
-    height: 28px;
-  }
 `;
 
 const BookmarkIconStyled = styled(BookmarkIcon)`

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,7 +27,8 @@
     "react-dom": "^18.2.0",
     "react-is": "^18.2.0",
     "styled-components": "^5.3.6",
-    "typescript": "4.9.4"
+    "typescript": "4.9.4",
+    "zustand": "^4.3.2"
   },
   "devDependencies": {
     "@svgr/webpack": "^6.5.1",

--- a/apps/web/pages/post/index.tsx
+++ b/apps/web/pages/post/index.tsx
@@ -1,29 +1,23 @@
 import { media } from "@chooz/ui/styles/media";
-import { useMutation } from "@tanstack/react-query";
 import { ImageTitleSection, TargetSection } from "components";
-import { postVoteAPI } from "lib/api/vote";
-import { useRouter } from "next/router";
 import React, { useState } from "react";
 import usePostVoteService from "services/usePostVoteService";
-import { useSubmitState } from "store/submitState";
 import styled from "styled-components";
 
 function PostPage() {
-  const { setIsSubmit } = useSubmitState();
-  const router = useRouter();
-  const { onChangeVote, vote, onUploadImage, onChangeVoteByClick, onChangeVoteBySelect } =
-    usePostVoteService();
+  const {
+    onChangeVote,
+    vote,
+    onUploadImage,
+    onChangeVoteByClick,
+    onChangeVoteBySelect,
+    mutateVote,
+    onPushSelectPage,
+  } = usePostVoteService();
   const [postStep, setPostStep] = useState<number>(1);
   const onChangePostStep = (step: number) => {
     setPostStep(step);
   };
-
-  const { mutate: mutateVote } = useMutation(() => postVoteAPI(vote), {
-    onSuccess: () => {
-      router.push("/");
-      setIsSubmit(true);
-    },
-  });
 
   return (
     <PageWrapper>
@@ -42,7 +36,7 @@ function PostPage() {
             vote={vote}
             onChangeVoteBySelect={onChangeVoteBySelect}
             mutateVote={mutateVote}
-            onChangePostStep={() => router.push("/select/1")}
+            onChangePostStep={onPushSelectPage}
           />
         )}
       </PageInner>

--- a/apps/web/pages/post/index.tsx
+++ b/apps/web/pages/post/index.tsx
@@ -5,9 +5,11 @@ import { postVoteAPI } from "lib/api/vote";
 import { useRouter } from "next/router";
 import React, { useState } from "react";
 import usePostVoteService from "services/usePostVoteService";
+import { useSubmitState } from "store/submitState";
 import styled from "styled-components";
 
 function PostPage() {
+  const { setIsSubmit } = useSubmitState();
   const router = useRouter();
   const { onChangeVote, vote, onUploadImage, onChangeVoteByClick, onChangeVoteBySelect } =
     usePostVoteService();
@@ -19,6 +21,7 @@ function PostPage() {
   const { mutate: mutateVote } = useMutation(() => postVoteAPI(vote), {
     onSuccess: () => {
       router.push("/");
+      setIsSubmit(true);
     },
   });
 

--- a/apps/web/pages/select/[id].tsx
+++ b/apps/web/pages/select/[id].tsx
@@ -8,11 +8,12 @@ import { HambergerIcon, SaveIcon } from "public/icons";
 import { Eximg1, Eximg2, Success } from "public/images";
 import React from "react";
 import useModifyVoteService from "services/useModifyVoteService";
+import { useSubmitState } from "store/submitState";
 import styled from "styled-components";
 
 function SelectPage() {
+  const { isSubmit, onToggleisSubmit } = useSubmitState();
   const [toggleDetail, onChangeToggleDetail] = useToggle(true);
-  const [toggleFirst, onChangeToggleFirst] = useToggle(true);
   const [toggleMenu, onChangeToggleMenu] = useToggle(false);
   const { onChangeVote, onChangeVoteByClick, mutateVote, vote } = useModifyVoteService();
   const { targetEl } = useOutSideClick(toggleMenu, onChangeToggleMenu);
@@ -62,8 +63,8 @@ function SelectPage() {
         </ImageWrapper>
         <AddDescriptionButton>﹢</AddDescriptionButton>
       </PageInner>
-      {toggleFirst && (
-        <FloatModalTemplate onToggleModal={onChangeToggleFirst}>
+      {isSubmit && (
+        <FloatModalTemplate onToggleModal={onToggleisSubmit}>
           <Image alt="체크" src={Success} width={56} height={56} />
           <GuideText>선택결정이 등록되었어요.</GuideText>
         </FloatModalTemplate>

--- a/apps/web/pages/select/[id].tsx
+++ b/apps/web/pages/select/[id].tsx
@@ -1,6 +1,6 @@
 import { FloatModalTemplate } from "@chooz/ui";
 import { media } from "@chooz/ui/styles/media";
-import SolversMessage from "components/common/SolversMessage";
+import NumberOfSolver from "components/common/NumberOfSolver";
 import TargetMessage from "components/common/TargetMessage";
 import AddDetailModal from "components/select/AddDetailModal";
 import useOutSideClick from "hooks/useOutsideClick";
@@ -24,7 +24,7 @@ function SelectPage() {
       <PageInner>
         <TagRow>
           <FlexRow>
-            <SolversMessage>🔥3,645명 해결중!</SolversMessage>
+            <NumberOfSolver>🔥3,645명 해결중!</NumberOfSolver>
             <TargetMessage>이 고민을 찾고있는 분이에요!</TargetMessage>
           </FlexRow>
           <FlexRow>

--- a/apps/web/pages/select/[id].tsx
+++ b/apps/web/pages/select/[id].tsx
@@ -1,5 +1,7 @@
 import { FloatModalTemplate } from "@chooz/ui";
 import { media } from "@chooz/ui/styles/media";
+import SolversMessage from "components/common/SolversMessage";
+import TargetMessage from "components/common/TargetMessage";
 import AddDetailModal from "components/select/AddDetailModal";
 import useOutSideClick from "hooks/useOutsideClick";
 import useToggle from "hooks/useToggle";
@@ -20,16 +22,11 @@ function SelectPage() {
   return (
     <PageWrapper>
       <PageInner>
-        <button onClick={onChangeToggleDetail}>asdasd</button>
         <TagRow>
           <FlexRow>
-            <div>3645명 해결중!</div>
-            <div>당신을 기다렸어요</div>
+            <SolversMessage>🔥3,645명 해결중!</SolversMessage>
+            <TargetMessage>이 고민을 찾고있는 분이에요!</TargetMessage>
           </FlexRow>
-          <div>22.02.03</div>
-        </TagRow>
-        <TitleRow>
-          <div>무엇이 좋을까요? 공백포함 34자 정도까지네요 여기까지입니다요</div>
           <FlexRow>
             <Image src={SaveIcon} alt="저장하기" width={32} height={32} />
             <div ref={targetEl}>
@@ -42,6 +39,12 @@ function SelectPage() {
               />
             </div>
           </FlexRow>
+        </TagRow>
+        <TitleRow>
+          <div>무엇이 좋을까요? 공백포함 34자 정도까지네요 여기까지입니다요</div>
+          <FlexRow>
+            <div>22.02.03</div>
+          </FlexRow>
           {toggleMenu && (
             <MenuBox>
               <MenuText className="modify" onClick={onChangeToggleDetail}>
@@ -53,15 +56,36 @@ function SelectPage() {
         </TitleRow>
         <ImageWrapper>
           <div>
-            <Image src={Eximg1} width={272} height={340} alt="A 이미지" />
+            <Image
+              src={Eximg1}
+              width={272}
+              height={340}
+              alt="A 이미지"
+              style={{
+                objectFit: "cover",
+                width: "272px",
+                height: "auto",
+              }}
+            />
             <SmallTitle>아이보리 트위드</SmallTitle>
           </div>
           <div>
-            <Image src={Eximg2} width={272} height={340} alt="B 이미지" />
+            <Image
+              src={Eximg2}
+              width={272}
+              height={340}
+              alt="B 이미지"
+              style={{
+                objectFit: "cover",
+                width: "272px",
+                height: "auto",
+              }}
+            />
             <SmallTitle>핑크 원피스</SmallTitle>
           </div>
         </ImageWrapper>
         <AddDescriptionButton>﹢</AddDescriptionButton>
+        {/* 자세히 보기 */}
       </PageInner>
       {isSubmit && (
         <FloatModalTemplate onToggleModal={onToggleisSubmit}>
@@ -90,13 +114,13 @@ const PageInner = styled.div`
   position: relative;
   margin: 0 auto;
   border-radius: 4px;
-  height: 558px;
+  height: 525px;
   background-color: white;
   max-width: 640px;
   position: relative;
   padding: 30px;
   ${media.medium} {
-    height: 717px;
+    height: 600px;
     padding: 40px;
   }
 `;
@@ -143,8 +167,8 @@ const AddDescriptionButton = styled.div`
   width: 64px;
   height: 64px;
   border-radius: 50%;
-  background-color: ${({ theme }) => theme.palette.background.white};
-  color: ${({ theme }) => theme.palette.ink.dark};
+  background-color: ${({ theme }) => theme.palette.ink.dark};
+  color: ${({ theme }) => theme.palette.background.white};
   font-size: 45px;
   box-shadow: rgba(100, 100, 111, 0.2) 0px 7px 29px 0px;
   cursor: pointer;
@@ -158,7 +182,7 @@ const FlexRow = styled.div`
 
 const MenuBox = styled.div`
   position: absolute;
-  top: 106px;
+  top: 70px;
   right: 41px;
   border-radius: 8px;
   background-color: ${({ theme }) => theme.palette.background.white};

--- a/apps/web/services/usePostVoteService.ts
+++ b/apps/web/services/usePostVoteService.ts
@@ -1,8 +1,14 @@
 import React, { useCallback, useState } from "react";
-import { PostVoteRequest } from "lib/api/vote";
+import { postVoteAPI, PostVoteRequest } from "lib/api/vote";
 import { uploadProfileImageAPI } from "lib/api/upload";
+import { useSubmitState } from "store/submitState";
+import { useMutation } from "@tanstack/react-query";
+import { useRouter } from "next/router";
 
 export default function usePostVoteService() {
+  const { setIsSubmit } = useSubmitState();
+  const router = useRouter();
+
   const [vote, setVote] = useState<PostVoteRequest>({
     title: "",
     detail: "",
@@ -71,6 +77,18 @@ export default function usePostVoteService() {
     }
   }, []);
 
+  const { mutate: mutateVote } = useMutation(() => postVoteAPI(vote), {
+    onSuccess: () => {
+      router.push("/");
+      setIsSubmit(true);
+    },
+  });
+
+  // 선택 페이지로 이동하는 함수
+  const onPushSelectPage = () => {
+    router.push("/select/1");
+  };
+
   return {
     vote,
     onChangeVote,
@@ -78,5 +96,7 @@ export default function usePostVoteService() {
     onUploadImage,
     onChangeVoteByClick,
     onChangeVoteBySelect,
+    mutateVote,
+    onPushSelectPage,
   };
 }

--- a/apps/web/store/submitState.tsx
+++ b/apps/web/store/submitState.tsx
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+export interface SubmitState {
+  isSubmit: boolean;
+  setIsSubmit: (isSubmitting: boolean) => void;
+  onToggleisSubmit: () => void;
+}
+
+export const useSubmitState = create<SubmitState>((set) => ({
+  isSubmit: false,
+  setIsSubmit: (isSubmit) => set({ isSubmit }),
+  onToggleisSubmit: () => set((state) => ({ isSubmit: !state.isSubmit })),
+}));

--- a/apps/web/types/index.d.ts
+++ b/apps/web/types/index.d.ts
@@ -1,3 +1,4 @@
 import "@chooz/ui";
 import "@tanstack/react-query";
 import "styled-components";
+import "zustand";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1607,6 +1607,7 @@ __metadata:
     react-is: ^18.2.0
     styled-components: ^5.3.6
     typescript: 4.9.4
+    zustand: ^4.3.2
   languageName: unknown
   linkType: soft
 
@@ -5246,7 +5247,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-sync-external-store@npm:^1.2.0":
+"use-sync-external-store@npm:1.2.0, use-sync-external-store@npm:^1.2.0":
   version: 1.2.0
   resolution: "use-sync-external-store@npm:1.2.0"
   peerDependencies:
@@ -5318,5 +5319,22 @@ __metadata:
   version: 0.1.0
   resolution: "yocto-queue@npm:0.1.0"
   checksum: f77b3d8d00310def622123df93d4ee654fc6a0096182af8bd60679ddcdfb3474c56c6c7190817c84a2785648cdee9d721c0154eb45698c62176c322fb46fc700
+  languageName: node
+  linkType: hard
+
+"zustand@npm:^4.3.2":
+  version: 4.3.2
+  resolution: "zustand@npm:4.3.2"
+  dependencies:
+    use-sync-external-store: 1.2.0
+  peerDependencies:
+    immer: ">=9.0"
+    react: ">=16.8"
+  peerDependenciesMeta:
+    immer:
+      optional: true
+    react:
+      optional: true
+  checksum: fc443abf5bc9deac0d4e375847e7914e44c7ffc9f7f09b60e466cb9bbbcf5a46706bf2f9c8b9e6e6c9a1c5aea0bd6123cbf9fbcd39788ae27d8494d505969ae8
   languageName: node
   linkType: hard


### PR DESCRIPTION
## 📑 작업리스트

- 모달 상태를 전역으로 관리하도록 변경

## 📘 리뷰노트

- zustand 사용했습니다
- targetMessage, NomverOfVote 부분 재사용을 위해 따로 분리했는데 추후 package/ui로 뺴는 작업 필요
