### PR TITLE
[CZ-513] 댓글 입력시 프로필 사진을 사용하도록 수정

### DIFF
--- a/apps/web/components/detail/CommentContainer.tsx
+++ b/apps/web/components/detail/CommentContainer.tsx
@@ -13,6 +13,7 @@ import { reactQueryKeys } from "lib/queryKeys";
 import useMutateCommentService from "services/useMutateCommentService";
 import useUpdateCommnetService from "services/useUpdateCommnetService";
 import useCommentFilter from "./hooks/useCommentFilter";
+import { useGetUserInfo } from "hooks/useGetUserInfo";
 
 interface Props {
   postId: number;
@@ -47,6 +48,8 @@ function CommentContainer({ postId }: Props) {
   } = useMutateCommentService(postId);
   const { mutateDeleteComment, mutateLike, mutateHate } = useUpdateCommnetService(postId);
 
+  const { data: userInfo } = useGetUserInfo();
+
   if (isLoading) return <div>로딩중</div>;
   if (isError) return <div>에러</div>;
   if (!comments) return <div>데이터 없음</div>;
@@ -63,6 +66,7 @@ function CommentContainer({ postId }: Props) {
         commentForm={commentForm}
         onChangeCommentForm={onChangeCommentForm}
         onSubmitComment={onSubmitComment}
+        profileImage={userInfo?.imageUrl}
       />
       {commentDatas.map((commentData) => (
         <Comment

--- a/apps/web/components/detail/CommentForm.tsx
+++ b/apps/web/components/detail/CommentForm.tsx
@@ -1,6 +1,6 @@
 import { Input } from "@chooz/ui";
 import Image from "next/image";
-import { Eximg1 } from "public/images";
+import { Eximg1, PurpleMonster } from "public/images";
 import React from "react";
 import styled, { css } from "styled-components";
 import { CommentForm } from "types/comments";
@@ -9,9 +9,10 @@ interface Props {
   commentForm: CommentForm;
   onSubmitComment: () => void;
   onChangeCommentForm: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  profileImage?: string;
 }
 
-function CommentForm({ commentForm, onChangeCommentForm, onSubmitComment }: Props) {
+function CommentForm({ commentForm, onChangeCommentForm, onSubmitComment, profileImage }: Props) {
   const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     onSubmitComment();
@@ -20,7 +21,7 @@ function CommentForm({ commentForm, onChangeCommentForm, onSubmitComment }: Prop
   return (
     <Container>
       <Image
-        src={Eximg1}
+        src={profileImage || PurpleMonster}
         alt="댓글 프로필"
         style={{
           width: "40px",


### PR DESCRIPTION
## 📑 작업리스트

- commentContainer에 유저정보를 가져오는 훅 사용
- commentForme에 props로 전달

## 📘 리뷰노트

- userInfo가 없을시 return하는 코드를 추가했더니, 로그인 하지 않고 접근시 코멘트창이 return문으로 인하여 보이지 않았습니다.
- 이에따라 optional chaining을 사용하도록 변경하였습니다.
