### PR TITLE
[CZ-540] 마이페이지 qa 작업

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -2,13 +2,12 @@
 
 import { theme } from "@chooz/ui";
 import styled, { ThemeProvider } from "styled-components";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { GlobalStyles } from "styles/globalStyles";
 import StyledComponentsRegistry from "../lib/registry";
 import useReplaceUser from "hooks/useReplaceUser";
 import Header from "components/common/header/Header";
 import { media } from "styles/media";
+import ReactQueryProvider from "lib/ReactQueryProvider";
 
 function RootLayout({
   // Layouts must accept a children prop.
@@ -17,16 +16,6 @@ function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        refetchOnWindowFocus: false,
-        staleTime: 1000 * 60 * 60 * 24,
-        cacheTime: 1000 * 60 * 60 * 24,
-      },
-    },
-  });
-
   useReplaceUser();
 
   return (
@@ -34,8 +23,7 @@ function RootLayout({
       <head></head>
       <body>
         <div id="portal" />
-        <QueryClientProvider client={queryClient}>
-          <ReactQueryDevtools />
+        <ReactQueryProvider>
           <StyledComponentsRegistry>
             <ThemeProvider theme={theme}>
               <GlobalStyles />
@@ -50,7 +38,7 @@ function RootLayout({
               </Applayout>
             </ThemeProvider>
           </StyledComponentsRegistry>
-        </QueryClientProvider>
+        </ReactQueryProvider>
       </body>
     </html>
   );

--- a/apps/web/app/my/components/UserInfoContainer.tsx
+++ b/apps/web/app/my/components/UserInfoContainer.tsx
@@ -5,18 +5,29 @@ import Link from "next/link";
 import { Gender } from "types/user";
 import styled, { css } from "styled-components";
 import { media } from "@chooz/ui/styles/media";
+import Image from "next/image";
 
 function UserInfoContainer() {
   const { data: userInfo } = useGetUserInfo();
 
   if (!userInfo) return <></>;
 
-  const { gender, username, age, mbti } = userInfo;
+  const { gender, username, age, mbti, imageUrl } = userInfo;
 
   return (
     <>
       <AddImageButtonWrapper>
-        <ImageUploadButton width="107px" height="107px" />
+        {imageUrl ? (
+          <Image
+            alt="프로필 사진"
+            src={imageUrl}
+            width={107}
+            height={107}
+            style={{ borderRadius: "8px" }}
+          />
+        ) : (
+          <ImageUploadButton width="107px" height="107px" />
+        )}
       </AddImageButtonWrapper>
       <Profile>
         <UserInfo>

--- a/apps/web/app/my/components/VoteItemDesktop.tsx
+++ b/apps/web/app/my/components/VoteItemDesktop.tsx
@@ -5,7 +5,7 @@ import { timeDataProcessing } from "lib/utils/timeDataProcessing";
 import Image from "next/image";
 import { AIcon, BIcon } from "public/icons";
 import styled, { css } from "styled-components";
-import { MyVote } from "types/vote";
+import { MyVote } from "types/my";
 
 interface Props {
   vote: MyVote;
@@ -151,11 +151,14 @@ const VoteTitle = styled.h3`
   overflow: hidden;
   white-space: nowrap;
   margin-top: 8px;
-  ${({ theme }) => theme.textStyle.Font_Regular}
-  ${media.medium} {
-    color: ${({ theme }) => theme.palette.ink.lightest};
-    ${({ theme }) => theme.textStyle.Title_Small}
-  }
+  ${({ theme }) =>
+    css`
+      ${theme.textStyle.Font_Regular}
+      ${media.medium} {
+        color: ${theme.palette.ink.darker};
+        ${theme.textStyle.Font_Regular}
+      }
+    `};
 `;
 
 const CommentAndDateContainer = styled.div`

--- a/apps/web/app/my/components/VoteItemDesktop.tsx
+++ b/apps/web/app/my/components/VoteItemDesktop.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { media } from "@chooz/ui/styles/media";
+import Path from "lib/Path";
 import { timeDataProcessing } from "lib/utils/timeDataProcessing";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 import { AIcon, BIcon } from "public/icons";
 import styled, { css } from "styled-components";
 import { MyVote } from "types/my";
@@ -12,11 +14,13 @@ interface Props {
 }
 
 function VoteItemDesktop({ vote }: Props) {
-  const { imageA, imageB, title, modifiedDate, countVoted, countComment } = vote;
+  const router = useRouter();
+
+  const { imageA, imageB, title, modifiedDate, countVoted, voteId } = vote;
 
   // @Todo Image에 sizes와 priority 추가
   return (
-    <Container>
+    <Container onClick={() => router.push(`${Path.VOTE_DETAIL_PAGE}/${voteId}`)}>
       <ABImage>
         {imageA ? (
           <ImageWrapper>
@@ -68,6 +72,7 @@ const Container = styled.div`
   height: 84px;
   margin-top: 20px;
   ${({ theme }) => theme.textStyle.Font_Minimum}
+  cursor: pointer;
 `;
 
 const ABImage = styled.div`

--- a/apps/web/app/my/components/VoteItemMobile.tsx
+++ b/apps/web/app/my/components/VoteItemMobile.tsx
@@ -3,8 +3,10 @@
 import { media } from "@chooz/ui/styles/media";
 import NumberOfSolver from "components/common/NumberOfSolver";
 import TargetMessage from "components/common/TargetMessage";
+import Path from "lib/Path";
 import { timeDataProcessing } from "lib/utils/timeDataProcessing";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 import { AIcon, BIcon, BookmarkIcon } from "public/icons";
 import styled, { css } from "styled-components";
 import { MyVote } from "types/my";
@@ -14,12 +16,14 @@ interface Props {
 }
 
 function VoteItemMobile({ vote }: Props) {
-  const { imageA, imageB, titleA, titleB, title, modifiedDate, countVoted } = vote;
+  const router = useRouter();
+
+  const { imageA, imageB, titleA, titleB, title, modifiedDate, countVoted, voteId } = vote;
   /**
    * @Todo Image에 sizes와 priority 추가
    */
   return (
-    <Container>
+    <Container onClick={() => router.push(`${Path.VOTE_DETAIL_PAGE}/${voteId}`)}>
       <ABImage>
         {imageA ? (
           <ImageWrapper>
@@ -70,6 +74,7 @@ function VoteItemMobile({ vote }: Props) {
 const Container = styled.div`
   margin-top: 20px;
   ${({ theme }) => theme.textStyle.Font_Minimum}
+  cursor: pointer;
 `;
 
 const ABImage = styled.div`

--- a/apps/web/app/my/components/VoteItemMobile.tsx
+++ b/apps/web/app/my/components/VoteItemMobile.tsx
@@ -15,8 +15,9 @@ interface Props {
 
 function VoteItemMobile({ vote }: Props) {
   const { imageA, imageB, titleA, titleB, title, modifiedDate, countVoted } = vote;
-
-  // @Todo Image에 sizes와 priority 추가
+  /**
+   * @Todo Image에 sizes와 priority 추가
+   */
   return (
     <Container>
       <ABImage>
@@ -76,14 +77,6 @@ const ABImage = styled.div`
   display: flex;
   max-width: 560px;
   margin: 0 auto;
-  /*  @todo 음영효과 추가
-  ::after {
-    content: "";
-    z-index: 99;
-    background-image: linear-gradient(to top, rgba(17, 17, 17, 0.6) 50%, rgba(17, 17, 17, 0) 18%);
-    width: 100px;
-    height: 100px;
-  } */
 `;
 
 const ImageWrapper = styled.div`
@@ -167,19 +160,25 @@ const VoteTitle = styled.h3`
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
-  ${({ theme }) => theme.textStyle.Font_Regular}
-  ${media.medium} {
-    color: ${({ theme }) => theme.palette.ink.lightest};
-    ${({ theme }) => theme.textStyle.Title_Small}
-  }
+  ${({ theme }) =>
+    css`
+      ${theme.textStyle.Font_Regular}
+      ${media.medium} {
+        color: ${({ theme }) => theme.palette.ink.lightest};
+        ${({ theme }) => theme.textStyle.Title_Small}
+      }
+    `};
 `;
 
 const VoteModifiedDate = styled.span`
-  color: ${({ theme }) => theme.palette.ink.base};
-  ${({ theme }) => theme.textStyle.Font_Regular}
-  ${media.medium} {
-    color: ${({ theme }) => theme.palette.ink.lightest};
-  }
+  ${({ theme }) =>
+    css`
+      color: ${theme.palette.ink.base};
+      ${theme.textStyle.Font_Regular};
+      ${media.medium} {
+        color: ${theme.palette.ink.lightest};
+      }
+    `};
 `;
 
 export default VoteItemMobile;

--- a/apps/web/app/my/components/VoteList.tsx
+++ b/apps/web/app/my/components/VoteList.tsx
@@ -1,6 +1,7 @@
 import { media } from "@chooz/ui/styles/media";
 import styled from "styled-components";
-import { MyVote } from "types/vote";
+import { MyVote } from "types/my";
+
 import VoteItemDesktop from "./VoteItemDesktop";
 import VoteItemMobile from "./VoteItemMobile";
 

--- a/apps/web/app/my/edit/components/HydratedUserInfo.tsx
+++ b/apps/web/app/my/edit/components/HydratedUserInfo.tsx
@@ -1,0 +1,17 @@
+import { dehydrate } from "@tanstack/react-query";
+import ProfileEditPage from "app/my/edit/components/Temp";
+import { getUserInfo } from "lib/apis/user";
+import getQueryClient from "lib/getQueryClient";
+import HydrateOnClient from "lib/hydrateOnClient";
+import { reactQueryKeys } from "lib/queryKeys";
+
+export default async function HydratedUserInfo() {
+  const queryClient = getQueryClient();
+  await queryClient.prefetchQuery(reactQueryKeys.userInfo(), getUserInfo);
+  const dehydratedState = dehydrate(queryClient);
+  return (
+    <HydrateOnClient state={dehydratedState}>
+      <ProfileEditPage />
+    </HydrateOnClient>
+  );
+}

--- a/apps/web/components/detail/Comment.tsx
+++ b/apps/web/components/detail/Comment.tsx
@@ -40,9 +40,9 @@ function Comment({ comment, mutateDeleteComment, mutateLike, mutateHate }: Props
       <Image
         src={imageUrl || PurpleMonster}
         alt="댓글 프로필"
+        width={40}
+        height={40}
         style={{
-          width: "40px",
-          height: "40px",
           borderRadius: "8px",
           marginRight: "10px",
         }}

--- a/apps/web/components/detail/VoteWriterBox.tsx
+++ b/apps/web/components/detail/VoteWriterBox.tsx
@@ -20,9 +20,9 @@ function VoteWriterBox({ writer }: Props) {
       <Image
         src={userImage || PurpleMonster}
         alt="댓글 프로필"
+        width={40}
+        height={40}
         style={{
-          width: "40px",
-          height: "40px",
           borderRadius: "8px",
         }}
       />

--- a/apps/web/lib/ReactQueryProvider.tsx
+++ b/apps/web/lib/ReactQueryProvider.tsx
@@ -1,0 +1,29 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { PropsWithChildren, useState } from "react";
+
+export default function ReactQueryProvider({ children }: PropsWithChildren) {
+  const [reactQueryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            refetchInterval: false,
+            refetchIntervalInBackground: false,
+            refetchOnWindowFocus: false,
+            refetchOnReconnect: false,
+            refetchOnMount: false,
+            staleTime: 1000 * 60 * 60 * 24,
+            cacheTime: 1000 * 60 * 60 * 24,
+          },
+        },
+      }),
+  );
+
+  return (
+    <QueryClientProvider client={reactQueryClient}>
+      {children}
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
+  );
+}

--- a/apps/web/lib/getQueryClient.tsx
+++ b/apps/web/lib/getQueryClient.tsx
@@ -1,0 +1,7 @@
+import { QueryClient } from "@tanstack/react-query";
+import { cache } from "react";
+
+// `QueryClient` 의 요청 범위 싱글톤 인스턴스를 만든다.
+// 이렇게 하면 서로 다른 사용자와 요청 간에 데이터가 공유되지 않고 여전히 요청당 한 번만 QueryClient를 생성한다.
+const getQueryClient = cache(() => new QueryClient());
+export default getQueryClient;

--- a/apps/web/lib/hydrateOnClient.tsx
+++ b/apps/web/lib/hydrateOnClient.tsx
@@ -1,0 +1,4 @@
+"use client";
+
+import { Hydrate as HydrateOnClient } from "@tanstack/react-query";
+export default HydrateOnClient;

--- a/apps/web/lib/utils/makeQueryHelper.ts
+++ b/apps/web/lib/utils/makeQueryHelper.ts
@@ -1,0 +1,120 @@
+import {
+  QueryClient,
+  QueryFunctionContext,
+  useInfiniteQuery,
+  useIsFetching,
+  useQuery,
+} from "@tanstack/react-query";
+import { TypedQueryClient } from "./types";
+
+type Awaited<T> = T extends Promise<infer U> ? (U extends Promise<unknown> ? Awaited<U> : U) : T;
+
+export const makeQueryHelper = <
+  TQueryFn extends (context: QueryFunctionContext) => (...args: any[]) => unknown,
+>({
+  queryClient,
+  baseQueryKey,
+  queryFn,
+}: {
+  queryClient: QueryClient;
+  baseQueryKey: string[];
+  queryFn: TQueryFn;
+}) => {
+  type TQueryFnArgs = Parameters<ReturnType<TQueryFn>>;
+  type TQueryFnResult = Awaited<ReturnType<ReturnType<TQueryFn>>>;
+
+  // @ts-expect-error
+  const queryFnArgsLength = queryFn().length;
+
+  const splitArgs = (args: any[]) => {
+    const queryFnArgs = args.slice(0, queryFnArgsLength);
+    const restArgs = args.slice(queryFnArgsLength);
+
+    return [queryFnArgs, restArgs];
+  };
+  const getQueryKey = (queryFnArgs: any[]) => [...baseQueryKey, ...queryFnArgs];
+  const getQueryFn = (queryFnArgs: any[]) => (context: QueryFunctionContext) =>
+    queryFn.call(null, context).apply(null, queryFnArgs);
+
+  const makeHookHandler =
+    (hook: any) =>
+    (...args: any[]) => {
+      const [queryFnArgs, [options]] = splitArgs(args);
+      return hook({
+        queryKey: getQueryKey(queryFnArgs),
+        queryFn: getQueryFn(queryFnArgs),
+        ...options,
+      });
+    };
+
+  const baseQueryHelper: Pick<
+    TypedQueryClient,
+    "withQueryClient" | "useIsFetching" | "useQuery" | "useInfiniteQuery"
+  > = {
+    useInfiniteQuery: makeHookHandler(useInfiniteQuery),
+    useQuery: makeHookHandler(useQuery),
+    useIsFetching: (...args) => {
+      const [queryFnArgs, [filters]] = splitArgs(args);
+      return useIsFetching(getQueryKey(queryFnArgs), { ...filters });
+    },
+    withQueryClient: (queryClient: QueryClient) => getQueryHelper(queryClient),
+  };
+
+  const getQueryHelper = (queryClient: QueryClient) => {
+    return new Proxy(baseQueryHelper, {
+      get(target: any, property: any) {
+        if (typeof target[property] !== "undefined") {
+          return target[property];
+        }
+
+        return (...args: any[]) => {
+          const [queryFnArgs, restArgs] = splitArgs(args);
+          const queryKey = getQueryKey(queryFnArgs);
+
+          const originalPropertyMap: any = {
+            setInfiniteQueriesData: "setQueriesData",
+            getInfiniteQueriesData: "getQueriesData",
+            getInfiniteQueryData: "getQueryData",
+            setInfiniteQueryData: "setQueryData",
+          };
+
+          let property$ = originalPropertyMap[property] || property;
+
+          switch (property$) {
+            case "fetchQuery":
+            case "prefetchQuery":
+            case "fetchInfiniteQuery":
+            case "prefetchInfiniteQuery":
+              return (queryClient as any)[property$]({
+                queryKey,
+                queryFn: getQueryFn(queryFnArgs),
+                ...restArgs[0],
+              });
+            case "getQueryData":
+            case "getQueryState":
+              return (queryClient as any)[property$]({
+                queryKey,
+                ...restArgs[0],
+              });
+            case "setQueryData":
+              return (queryClient as any)[property$](queryKey, ...restArgs);
+            case "setQueriesData":
+            case "invalidateQueries":
+            case "refetchQueries":
+            case "cancelQueries":
+            case "removeQueries":
+            case "resetQueries":
+            case "isFetching":
+              return (queryClient as any)[property$](baseQueryKey, ...args);
+            case "getQueriesData":
+              return (queryClient as any)[property$](args[0] || { queryKey });
+            default:
+              return target[property$];
+          }
+        };
+      },
+    });
+  };
+
+  return getQueryHelper(queryClient) as TypedQueryClient<TQueryFnArgs, TQueryFnResult, Error>;
+};

--- a/apps/web/lib/utils/types.ts
+++ b/apps/web/lib/utils/types.ts
@@ -1,0 +1,112 @@
+import type {
+  CancelOptions,
+  FetchInfiniteQueryOptions,
+  FetchQueryOptions,
+  InfiniteData,
+  InvalidateOptions,
+  InvalidateQueryFilters,
+  QueryClient,
+  QueryFilters,
+  QueryKey,
+  QueryState,
+  RefetchOptions,
+  RefetchQueryFilters,
+  ResetOptions,
+  ResetQueryFilters,
+  SetDataOptions,
+  Updater,
+  UseInfiniteQueryOptions,
+  UseInfiniteQueryResult,
+  useIsFetching,
+  UseQueryOptions,
+  UseQueryResult,
+} from "@tanstack/react-query";
+// import { QueryState } from "react-query/types/core/query";
+// import { QueryFilters, Updater } from "react-query/types/core/utils";
+
+export interface TypedQueryClient<
+  TQueryFnArgs extends unknown[] = [],
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+> {
+  isFetching(filters?: QueryFilters): number;
+  fetchQuery(
+    ...args: [
+      ...args: TQueryFnArgs,
+      options?: FetchQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    ]
+  ): Promise<TData>;
+  prefetchQuery(
+    ...args: [
+      ...args: TQueryFnArgs,
+      options?: FetchQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    ]
+  ): Promise<void>;
+  fetchInfiniteQuery(
+    ...args: [
+      ...args: TQueryFnArgs,
+      options?: FetchInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    ]
+  ): Promise<InfiniteData<TData>>;
+  prefetchInfiniteQuery(
+    ...args: [
+      ...args: TQueryFnArgs,
+      options?: FetchInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    ]
+  ): Promise<void>;
+  getQueryData(...args: [...args: TQueryFnArgs, filters?: QueryFilters]): TData | undefined;
+  getQueriesData(filters?: QueryFilters): [QueryKey, TData][];
+  setQueryData(
+    ...args: [
+      ...args: TQueryFnArgs,
+      updater: Updater<TData | undefined, TData | undefined>,
+      options?: SetDataOptions,
+    ]
+  ): TData;
+  setQueriesData(updater: Updater<TData | undefined, TData | undefined>): [QueryKey, TData][];
+  getQueryState(
+    ...args: [...args: TQueryFnArgs, filters?: QueryFilters]
+  ): QueryState<TData, TError> | undefined;
+  invalidateQueries<TPageData = unknown>(
+    filters?: InvalidateQueryFilters<TPageData>,
+    options?: InvalidateOptions,
+  ): Promise<void>;
+  refetchQueries<TPageData = unknown>(
+    filters?: RefetchQueryFilters<TPageData>,
+    options?: RefetchOptions,
+  ): Promise<void>;
+  cancelQueries(filters?: QueryFilters, options?: CancelOptions): Promise<void>;
+  removeQueries(filters?: QueryFilters): void;
+  resetQueries<TPageData = unknown>(
+    filters?: ResetQueryFilters<TPageData>,
+    options?: ResetOptions,
+  ): Promise<void>;
+
+  // Custom
+  withQueryClient(queryClient: QueryClient): TypedQueryClient<TQueryFnArgs, TQueryFnData, TError>;
+  setInfiniteQueriesData(
+    updater: Updater<InfiniteData<TData> | undefined, InfiniteData<TData> | undefined>,
+  ): [QueryKey, InfiniteData<TData>][];
+  getInfiniteQueriesData(filters?: QueryFilters): [QueryKey, InfiniteData<TData>][];
+  setInfiniteQueryData(
+    ...args: [
+      ...args: TQueryFnArgs,
+      updater: Updater<InfiniteData<TData> | undefined, InfiniteData<TData> | undefined>,
+      options?: SetDataOptions,
+    ]
+  ): InfiniteData<TData>;
+  getInfiniteQueryData(
+    ...args: [...args: TQueryFnArgs, filters?: QueryFilters]
+  ): InfiniteData<TData> | undefined;
+
+  // Hooks
+  useIsFetching(...args: [...args: TQueryFnArgs, filters?: QueryFilters]): number;
+  useQuery(
+    ...args: [...args: TQueryFnArgs, filters?: UseQueryOptions<TQueryFnData, TError>]
+  ): UseQueryResult<TData, TError>;
+  useInfiniteQuery(
+    ...args: [...args: TQueryFnArgs, filters?: UseInfiniteQueryOptions<TQueryFnData, TError>]
+  ): UseInfiniteQueryResult<TData, TError>;
+}


### PR DESCRIPTION
## 📑 작업리스트

- 데스크탑 버전에서 제목이 보이지 않던 버그 수정
- 상세 페이지 Image 태그에 width, height값 추가
- 마이 페이지에서 투표를 클릭하면 해당 투표 상세 페이지로 이동
- 마이 페이지에서 업로드한 프로필 이미지를 확인 할 수 있도록 구현
- ReactQuery를 효율적으로 사용할 수 있도록 구현
- queryClient 별도 파일로 분리
- app directory에서 ReactQuery 사용시 pre-fetch로 데이터를 전달하기 위한 코드 추가

## 📘 리뷰노트
- 기존 클라이언트 컴포넌트에서 서버 컴포넌트로 변경하기 쉽지 않아 pre-fetch 적용을 아직 못했습니다.
